### PR TITLE
Exposições de curta duração

### DIFF
--- a/src/controllers/ExpositionController.js
+++ b/src/controllers/ExpositionController.js
@@ -33,7 +33,7 @@ const registerExposition = async (req, res, next) => {
       type: parseInt(type),
       image,
       description,
-      artWorks,
+      artWorks: artWorks || [],
       place,
       dateStarts,
       dateEnds,

--- a/src/validations/expositionValidations.js
+++ b/src/validations/expositionValidations.js
@@ -35,10 +35,9 @@ const expositionCreateValidation = () => {
       .withMessage("O título precisa ter no mínimo três caracteres."),
     body("description").isString().withMessage("A descrição é obrigatória."),
     body("artWorks")
+      .optional()
       .isArray()
-      .withMessage("Formato de dado inválido.")
-      .isLength({ min: 1 })
-      .withMessage("A exposição precisa ter mais de uma obra."),
+      .withMessage("Formato de dado inválido."),
     body("place").isString().withMessage("O local da exposição é obrigatório."),
     body("dateStarts").isDate().withMessage("Adicione uma data válida."),
     body("dateEnds").isDate().withMessage("Adicione uma data válida."),


### PR DESCRIPTION
As vezes é necessário criar uma exposição de curta duração antes mesmo de cadastrar as obras dela, mas a plataforma não permitia criar exposição sem obras.